### PR TITLE
Add a proposal for exposing the front-side pads on the back side

### DIFF
--- a/Connector_DebugEdge.pretty/DebugEdge_2x05_Target.kicad_mod
+++ b/Connector_DebugEdge.pretty/DebugEdge_2x05_Target.kicad_mod
@@ -1,4 +1,4 @@
-(module DebugEdge_2x05_Target (layer F.Cu) (tedit 5F5EA317)
+(module DebugEdge_2x05_Target (layer F.Cu) (tedit 5FC829FF)
   (attr virtual)
   (fp_text reference REF** (at 0 1.2 unlocked) (layer F.Fab)
     (effects (font (size 0.5 0.5) (thickness 0.05)))
@@ -123,5 +123,40 @@
          (xy 0.3 1) (xy 0.31 0.89) (xy 0.33 0.81) (xy 0.35 0.75) (xy 0.37 0.7)
          (xy 0.4 0.65) (xy 0.44 0.59) (xy 0.48 0.54) (xy 0.5 0.52) (xy 0.5 -0.5)
          (xy -0.5 -0.5) (xy -0.5 3.2) (xy 0.3 3.2)) (width 0))
+    ))
+  (pad 9 smd custom (at 4 -5.25 180) (size 1 1.9) (layers B.Cu B.Mask)
+    (zone_connect 0)
+    (options (clearance outline) (anchor rect))
+    (primitives
+      (gr_poly (pts
+         (xy -0.5 -1.05) (xy -0.5 -0.95) (xy 0.5 -0.95)) (width 0))
+    ))
+  (pad 5 smd custom (at 2 -5.35 180) (size 1 1.7) (layers B.Cu B.Mask)
+    (zone_connect 0)
+    (options (clearance outline) (anchor rect))
+    (primitives
+      (gr_poly (pts
+         (xy -0.5 -0.95) (xy -0.5 -0.85) (xy 0.5 -0.85)) (width 0))
+    ))
+  (pad 2 smd custom (at 0 -5.45 180) (size 1 1.5) (layers B.Cu B.Mask)
+    (zone_connect 0)
+    (options (clearance outline) (anchor rect))
+    (primitives
+      (gr_poly (pts
+         (xy -0.5 -0.85) (xy -0.5 -0.75) (xy 0.5 -0.75)) (width 0))
+    ))
+  (pad 1 smd custom (at -2 -5.45 180) (size 1 1.5) (layers B.Cu B.Mask)
+    (zone_connect 0)
+    (options (clearance outline) (anchor rect))
+    (primitives
+      (gr_poly (pts
+         (xy 0.5 -0.85) (xy 0.5 -0.75) (xy -0.5 -0.75)) (width 0))
+    ))
+  (pad 7 smd custom (at -4 -5.35 180) (size 1 1.7) (layers B.Cu B.Mask)
+    (zone_connect 0)
+    (options (clearance outline) (anchor rect))
+    (primitives
+      (gr_poly (pts
+         (xy 0.5 -0.95) (xy 0.5 -0.85) (xy -0.5 -0.85)) (width 0))
     ))
 )


### PR DESCRIPTION
As mentioned on Twitter, I'd get value out of being able to use this same connector for pogo-pin programming.  This PR is a proposal for how we might expose the front-side pads to the back side of the device footprint. If this looks good, I'd be happy to modify the other device footprints accordingly. 